### PR TITLE
Typo "CurrentStep" instead of "CurrentSet" in M5_TrainModel.py

### DIFF
--- a/Code/M5_TrainModel.py
+++ b/Code/M5_TrainModel.py
@@ -134,7 +134,7 @@ if mode=='C':
           UF.SubmitTrainJobCondor(AFS_DIR,EOS_DIR,PreviousJob[0],'Train')
         if CurrentSet>1:
           UF.SubmitTrainJobCondor(AFS_DIR,EOS_DIR,PreviousJob[0],'Train')
-        print(UF.TimeStamp(), bcolors.OKGREEN+"The Training Job for the CurrentSet",CurrentStep,"have been resubmitted"+bcolors.ENDC)
+        print(UF.TimeStamp(), bcolors.OKGREEN+"The Training Job for the CurrentSet",CurrentSet,"have been resubmitted"+bcolors.ENDC)
         print(bcolors.OKGREEN+"Please check it in a few hours"+bcolors.ENDC)
         exit()
    else:


### PR DESCRIPTION
Dear Filips,

Code M5_TrainModel.py failed to launch due to undefined variable "CurrentStep".
Checking the code, it appears to be a simple typo: I believe it should be "CurrentSet".

Best regards,
Antonio